### PR TITLE
Add new codes

### DIFF
--- a/doc/starType.tex
+++ b/doc/starType.tex
@@ -44,6 +44,7 @@ command & produces\\
 |\ADIPLS| & \ADIPLS \\
 |\DSEP| & \DSEP \\
 |\enzo| & \enzo \\
+|\amrex,\AMReX| & \amrex \\
 |\Castro| & \Castro \\
 |\Maestro| & \Maestro \\
 \hline

--- a/doc/starType.tex
+++ b/doc/starType.tex
@@ -45,6 +45,7 @@ command & produces\\
 |\DSEP| & \DSEP \\
 |\enzo| & \enzo \\
 |\amrex,\AMReX| & \amrex \\
+|\boxlib,\BoxLib| & \boxlib \\
 |\Castro| & \Castro \\
 |\Maestro| & \Maestro \\
 \hline

--- a/macros/st_code.tex
+++ b/macros/st_code.tex
@@ -17,9 +17,11 @@
 \newcommand{\netJina}{\code{netJina}}
 \newcommand{\starType}{\code{starType}}
 \newcommand{\AMReX}{\code{AMReX}}
+\newcommand{\BoxLib}{\code{BoxLib}}
 \newcommand{\Castro}{\code{Castro}}
 \newcommand{\Maestro}{\code{Maestro}}
 \newcommand{\amrex}{\AMReX}
+\newcommand{\boxlib}{\BoxLib}
 \newcommand{\castro}{\Castro}
 \newcommand{\maestro}{\Maestro}
 

--- a/macros/st_code.tex
+++ b/macros/st_code.tex
@@ -16,8 +16,10 @@
 \newcommand{\dStar}{\code{dStar}}
 \newcommand{\netJina}{\code{netJina}}
 \newcommand{\starType}{\code{starType}}
+\newcommand{\AMReX}{\code{AMReX}}
 \newcommand{\Castro}{\code{Castro}}
 \newcommand{\Maestro}{\code{Maestro}}
+\newcommand{\amrex}{\AMReX}
 \newcommand{\castro}{\Castro}
 \newcommand{\maestro}{\Maestro}
 


### PR DESCRIPTION
I've added new codes to starType.  Namely, the AMReX and it's predecessor BoxLib.  AMReX is the underlying AMR framework that Castro, Maestro, and several other codes are built on top of.